### PR TITLE
#15 Adding Attachments to emails

### DIFF
--- a/ec_email_client/src/pages/CreateEmail.js
+++ b/ec_email_client/src/pages/CreateEmail.js
@@ -34,17 +34,27 @@ class EmailComposition extends React.Component {
     }
 
     onFileChange(event) {
-        this.setState({file: event.target.files[0]});
-        let file1 = event.target.files[0];
-        this.validateAttachment(file1);
+        //Only update to file if initializing, not cancelling attachment
+        if(event.target.value.length != 0){
+            this.setState({file: event.target.files[0]});
+            let file1 = event.target.files[0];
+            if(this.validateAttachment(file1) == false){
+                event.target.value = '';
+            }
 
-        //Encode Attachment to base 64
-        this.getBase64(file1, (result) => {
-            var file64a = result;
-            var file64b = result.split('base64,')[1];
-            //console.log(file64);
-            this.setState({file64: file64b});
-        });
+            //Encode Attachment to base 64
+            this.getBase64(file1, (result) => {
+                var file64a = result;
+                var file64b = result.split('base64,')[1];
+                //console.log(file64);
+                this.setState({file64: file64b});
+            });
+        }
+        //No file was chosen, reset values
+        else{
+            this.setState({file: '', file64: ''});
+            event.target.value = '';
+        }
 
     }
 
@@ -66,7 +76,9 @@ class EmailComposition extends React.Component {
             alert("Attachments cannot exceed 25MB");
             this.setState({file: '',
                            file64: ''});
+            return false;
         }
+        return true;
     }
 
     //JS Fetch API to send the form data
@@ -142,8 +154,6 @@ class EmailComposition extends React.Component {
                 },
             })
             .then((result) => {
-                console.log(result);
-                console.log(result.status);
                 if (result.status == 200) {
                     //Alert that the email sending was a success
                     alert("Message Sent Successfully");
@@ -204,7 +214,8 @@ class EmailComposition extends React.Component {
                         <input
                             type="file"
                             className="form-control"
-                            name="file"
+                            name="fileInput"
+                            id="formAttachment"
                             onChange={this.onFileChange.bind(this)}
                         />
                     </div>

--- a/ec_email_client/src/pages/CreateEmail.js
+++ b/ec_email_client/src/pages/CreateEmail.js
@@ -34,9 +34,9 @@ class EmailComposition extends React.Component {
     }
 
     onFileChange(event) {
-
-        this.setState({file: event.target.files[0]})
+        this.setState({file: event.target.files[0]});
         let file1 = event.target.files[0];
+        this.validateAttachment(file1);
 
         //Encode Attachment to base 64
         this.getBase64(file1, (result) => {
@@ -45,6 +45,7 @@ class EmailComposition extends React.Component {
             //console.log(file64);
             this.setState({file64: file64b});
         });
+
     }
 
     //Need to keep original file data, but also must encode to send
@@ -59,9 +60,17 @@ class EmailComposition extends React.Component {
         };
     }
 
+    //Testing that file size is under 25MB
+    validateAttachment(fileTest){
+        if(fileTest.size > 25000000){
+            alert("Attachments cannot exceed 25MB");
+            this.setState({file: '',
+                           file64: ''});
+        }
+    }
+
     //JS Fetch API to send the form data
     handleSubmit(event) {
-        //this.initClient();
         event.preventDefault();
         //Must encode subject line
         const utf8Subject = `=?utf-8?B?${Buffer.from(
@@ -73,9 +82,11 @@ class EmailComposition extends React.Component {
         //Split the multiple recipients's (if there are multiple) and change commas to tags
         //This solution works if a gmail address goes first???
         var toSend = this.state.recipient.replace(",", ", ");
+        var CCs = this.state.cc.replace(",", ", ");
 
         var messageParts = [
             `To: ${toSend}`,
+            `CC: ${CCs}`,
             "Content-Type: text/html; charset=utf-8",
             "MIME-Version: 1.0",
             `Subject: ${utf8Subject}`,
@@ -83,22 +94,6 @@ class EmailComposition extends React.Component {
             this.state.message,
         ];
 
-        //If there is a cc, need a different format
-        //Works if the first address is a gmail. Makes 0 sense to me.
-        if (this.state.cc != "") {
-            //Split the multiple cc's(if there are multiple) and change commas to tags
-            var CCs = this.state.cc.replace(",", ", ");
-
-            messageParts = [
-                `To: ${toSend}`,
-                `CC: ${CCs}`,
-                "Content-Type: text/html; charset=utf-8",
-                "MIME-Version: 1.0",
-                `Subject: ${utf8Subject}`,
-                "",
-                this.state.message,
-            ];
-        }
 
         //If the email has an attachment, it needs to use the multipart structure
         if (this.state.file != "") {
@@ -106,8 +101,8 @@ class EmailComposition extends React.Component {
             var messageParts = [
                 `Content-Type: multipart/mixed; boundary="foo_bar_baz"`, 
                 "MIME-Version: 1.0",
-                //`Content-Disposition: ${this.state.file.name}`,
                 `To: ${toSend}`,
+                `CC: ${CCs}`,
                 `Subject: ${utf8Subject}`,
                 "",
 

--- a/ec_email_client/src/pages/InboxPage.js
+++ b/ec_email_client/src/pages/InboxPage.js
@@ -122,7 +122,7 @@ function InboxPage(props) {
         return atob(data);
     }
 
-    function Test() {
+    function LoadEmails() {
         getAllMessages(emails.length += 10).then((emails) => {
             setEmails(emails);
         });
@@ -190,7 +190,7 @@ function InboxPage(props) {
                         {emails.map((email) => {
                             return <InboxEmailRow key={email.id} message={email} />;
                         })}
-                        {<button class="loadMoreButton" onClick={Test}>Load More</button>}
+                        {<button class="loadMoreButton" onClick={LoadEmails}>Load More</button>}
                     </tbody>
                 </Table>
             </div>
@@ -296,7 +296,7 @@ function ViewEmailModal(props) {
 function CreateEmailModal(props) {
     return (
         <Modal isOpen={props.isOpen} toggle={props.toggle} id="emailPopupModal">
-            <ModalHeader toggle={props.toggle}>Create Eamil</ModalHeader>
+            <ModalHeader toggle={props.toggle}>Create Email</ModalHeader>
             <ModalBody>
                 <EmailComposition toggle={props.toggle} />
             </ModalBody>


### PR DESCRIPTION
#15 Add Attachments to an email. This enables users to send attachments with their emails. Limits size at 25MB, gives alert and removes attachment if file exceeds size. GAPI limits what types of files can be sent (ex. no .js files). When testing this, check for attachments on real email client. Attachments do not show up in our inbox. 

closes #15 