### PR TITLE
#44 Reply bug fix

### DIFF
--- a/ec_email_client/src/pages/CreateEmail.js
+++ b/ec_email_client/src/pages/CreateEmail.js
@@ -19,11 +19,15 @@ class EmailComposition extends React.Component {
 
         // Formats fields if it is a reply
         if (this.props.reply) {
-            let recipientField = this.props.replyMessage.from.split("<")[1];
-            recipientField = recipientField.substring(
-                0,
-                recipientField.length - 1
-            );
+            console.log(this.props.replyMessage);
+            let recipientField = this.props.replyMessage.from;
+            if (this.props.replyMessage.from.split("<").length > 1) {
+                recipientField = this.props.replyMessage.from.split("<")[1];
+                recipientField = recipientField.substring(
+                    0,
+                    recipientField.length - 1
+                );
+            }
 
             this.state = {
                 recipient: recipientField,


### PR DESCRIPTION
Normal emails have a name in the from field (ex Patrick Bell <pjb183@msstate.edu>) and we were parsing out the name to just get the email (did a split operation on '<') but when sending our own emails to ourselves it only had the email address, not the name, so the split operation was failing. I created a if/else section that checks if the name is in the from field to compensate for this.

Closes #44 