### PR TITLE
Stopped issue from occurring when user replies to their own email

### DIFF
--- a/ec_email_client/src/components/InboxPageComponent.js
+++ b/ec_email_client/src/components/InboxPageComponent.js
@@ -317,6 +317,30 @@ export default class InboxPageComponent extends React.Component {
                     resolve(values);
                 });
             }).then((newEmails) => {
+
+                // Utility for splitting array into groups based on element property
+                function groupByUtil(arr, property) {
+                    return arr.reduce(function(memo, x) {
+                      if (!memo[x[property]]) { memo[x[property]] = []; }
+                      memo[x[property]].push(x);
+                      return memo;
+                    }, {});
+                }
+
+                // BUG: A "bug" exists in our system such that when a user replies to their
+                // own email, the gmail API will detect two emails. This ensures that only the
+                // "true" email reply is picked up while the other, assumed to be some artifact that
+                // EC Email Client is not taking into account of, is ignored
+                // David Mentgen - 10/17/2020
+                var groupedNewEmails = groupByUtil(newEmails, "snippet");
+                for (var key in groupedNewEmails) {
+                    if (groupedNewEmails[key].length == 2) {
+                        newEmails = newEmails.filter(function(obj) {
+                            return obj.id !== groupedNewEmails[key][1].id;
+                        });
+                    }
+                }
+
                 if (newEmails.length > 0) {
                     newEmails.forEach(newEmail => {
                         newLoadedEmails.unshift(newEmail);


### PR DESCRIPTION
As the title states, this stops the issue found in #50 from occurring.

During my testing, I noticed the following things to be consistently true:
- Issue occurs when user replies to their own email
- When issue occurs, the user will always receive what is assumed to be a "reply-email artifact" and their actual response in this order

Given the previously mentioned observation, I chose to adjust the inbox refresher to perform a groupBy operation on the incoming new emails. If it detects that we have duplicates occurring, it will then preserve the "actual reply" and toss out the "reply-email artifact".

It should be noted that this is likely not a total solution, but for the sake of time and pursuing the enhancement of our core features I think this will get us through to version 1.0 for now. Especially since this is an edge case that should probably not occur often.