### PR TITLE
Fixed issue with loading new emails inaccurately displaying new emails

### DIFF
--- a/ec_email_client/src/components/InboxPageComponent.js
+++ b/ec_email_client/src/components/InboxPageComponent.js
@@ -280,9 +280,10 @@ export default class InboxPageComponent extends React.Component {
             this.setState({displayedEmails: emailsToBeDisplayed});
         } else {
             this.getMessages().then((emails) => {
-                this.setState({loadedEmails: emails});
+                var emailsToBeLoaded = this.state.loadedEmails;
+                this.setState({loadedEmails: emailsToBeLoaded.concat(emails)});
 
-                var emailsToBeDisplayed = emails.slice(0, this.state.displayedEmails.length + 20);
+                var emailsToBeDisplayed = emailsToBeLoaded.slice(0, this.state.displayedEmails.length + 20);
                 this.setState({displayedEmails: emailsToBeDisplayed});
             });
         }


### PR DESCRIPTION
#52 

**Problem**
EC Email Client keeps track of two lists:
LoadedEmails = []
DisplayedEmails = []

Where LoadedEmails is the total list of emails that we have loaded from gmail. This list allows us to page from gmail 100 emails at a time. We store them so that we don't have to always git the gmail api for more emails. DisplayedEmails is the list of emails from LoadedEmails that we are currently displaying to the user.

The issue was that whenever DisplayedEmails.length() % 100 == 0 (In this case, we need to retrieve the next page of emails from gmail), we were incorrectly updating the DisplayedEmails and LoadedEmails arrays.

This should now be resolved.