### PR TITLE
#36 & #46 Bug fix: Attachment with highlights and replying with attachments

### DIFF
--- a/ec_email_client/package-lock.json
+++ b/ec_email_client/package-lock.json
@@ -8298,6 +8298,25 @@
         "mime-db": "1.44.0"
       }
     },
+    "mimemessage": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mimemessage/-/mimemessage-1.0.5.tgz",
+      "integrity": "sha512-SCLRPGzMRssW7mKF8gg3ZbpDZ+6HTfXGK78LQ/CAHJcJZr5jQmmCKGbG3y5ut8UP5unxBF/9KkED0xmk3vt8NA==",
+      "requires": {
+        "debug": "^3.1.0",
+        "random-string": "^0.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -10419,6 +10438,11 @@
       "requires": {
         "performance-now": "^2.1.0"
       }
+    },
+    "random-string": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/random-string/-/random-string-0.2.0.tgz",
+      "integrity": "sha1-pG5DdTUr7amg17DRntbTIezR2C0="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/ec_email_client/package.json
+++ b/ec_email_client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^7.2.1",
     "@tinymce/tinymce-react": "^3.7.0",
     "bootstrap": "^4.5.2",
+    "mimemessage": "^1.0.5",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",

--- a/ec_email_client/src/components/InboxPageComponent.js
+++ b/ec_email_client/src/components/InboxPageComponent.js
@@ -234,8 +234,9 @@ export default class InboxPageComponent extends React.Component {
                         message.snippet = response.result.snippet;
                     }
 
-                    if (response.result.threadId)
+                    if (response.result.threadId) {
                         message.threadId = response.result.threadId;
+                    }
 
                     // Gets all headers, turns in to dict
                     let headers = {};
@@ -257,9 +258,6 @@ export default class InboxPageComponent extends React.Component {
                     message.headers = headers;
 
                     message.id = response.result.id;
-                    if (message.id == "1753f0c7fcbb8c2a") {
-                        console.log(response.result);
-                    }
 
                     resolve(message);
                 });

--- a/ec_email_client/src/components/InboxPageComponent.js
+++ b/ec_email_client/src/components/InboxPageComponent.js
@@ -74,7 +74,7 @@ export default class InboxPageComponent extends React.Component {
                     pageToken: this.state.nextPageToken
                 })
                 .then((response) => {
-                    this.setState({nextPageToken: response.result.nextPageToken});
+                    this.setState({ nextPageToken: response.result.nextPageToken });
                     resolve(response.result.messages);
                 });
         });
@@ -124,7 +124,6 @@ export default class InboxPageComponent extends React.Component {
                 .then((response) => {
                     //console.log(response.result);
 
-
                     // We need to actually iterate through the email parts and see what they are and properly assign them 
                     var partsCounter;
                     if (
@@ -133,10 +132,10 @@ export default class InboxPageComponent extends React.Component {
                     ) {
                         // Iterate through all the message parts and check if there is a file name, and check MimeType to assign correctly  
                         for (partsCounter = 0; partsCounter < response.result.payload.parts.length; partsCounter++) {
-                            
+
                             // There are many different MIME Types for attachments, just check if filename exists, if true, we have a file
                             if (response.result.payload.parts[partsCounter].filename) {
-                                message.attachmentName = 
+                                message.attachmentName =
                                     response.result.payload.parts[partsCounter].filename;
 
                                 //Need to check for mime type so download works correctly
@@ -144,8 +143,8 @@ export default class InboxPageComponent extends React.Component {
 
                                 //Must build correct .attachment format for download function
                                 var MessageData = this.getAttachmentData(messageId, response.result.payload.parts[partsCounter]);
-                                MessageData.then(function (result){
-                                    message.attachment = 'data:'+mimeTypeCheck+';base64,'+result.result.data;
+                                MessageData.then(function (result) {
+                                    message.attachment = 'data:' + mimeTypeCheck + ';base64,' + result.result.data;
                                 });
                             }
                             //We still need to properly assign part to correct piece of email based on mime type
@@ -159,28 +158,44 @@ export default class InboxPageComponent extends React.Component {
                                     response.result.payload.parts[partsCounter].body.data
                                 );
                             }
+
+                            // If part has subparts that contain text or data (often when included with attachments), then get data out of there
+                            if (response.result.payload.parts[partsCounter].parts && response.result.payload.parts[partsCounter].parts.length > 0) {
+                                // Cycles through all parts and assign appropriate plain or html variables
+                                for (let i = 0; i < response.result.payload.parts[partsCounter].parts.length; i++) {
+                                    let part = response.result.payload.parts[partsCounter].parts[i];
+                                    if (part.mimeType == "text/plain") {
+                                        message.bodyText = this.decodeBase64HTML(
+                                            part.body.data
+                                        );
+                                    }
+                                    if (part.mimeType == "text/html") {
+                                        message.bodyHTML = this.decodeBase64HTML(
+                                            part.body.data
+                                        );
+                                    }
+                                }
+                            }
                         }
 
-                    // If message only has one (1) part, properly assign its data to corresponding piece 
+                        // If message only has one (1) part, properly assign its data to corresponding piece
                     } else if (
                         !!response.result.payload.body &&
                         !!response.result.payload.body.data
                     ) {
-
                         switch (response.result.payload.mimeType) {
-                            case ("text/plain"):
+                            case "text/plain":
                                 message.bodyText = this.decodeBase64HTML(
                                     response.result.payload.body.data
                                 );
                                 break;
 
-                            case ("text/html"):
+                            case "text/html":
                                 message.bodyHTML = this.decodeBase64HTML(
                                     response.result.payload.body.data
                                 );
                                 break;
                         }
-
 
                         // Checks if HTML was put in body.data
                         if (
@@ -228,12 +243,13 @@ export default class InboxPageComponent extends React.Component {
                     message.id = response.result.id;
                     resolve(message);
                 });
-
         });
     }
 
     downloadAttachment(e) {
-        let dataBase64Rep = e.message.attachment.replace(/-/g, '+').replace(/_/g, '/')
+        let dataBase64Rep = e.message.attachment
+            .replace(/-/g, "+")
+            .replace(/_/g, "/");
         var attachmentForDownload = document.createElement("a");
         attachmentForDownload.href = dataBase64Rep;
         attachmentForDownload.download = e.message.attachmentName;
@@ -277,13 +293,13 @@ export default class InboxPageComponent extends React.Component {
     LoadEmails() {
         if (this.state.displayedEmails.length + 20 < this.state.loadedEmails.length) {
             var emailsToBeDisplayed = this.state.loadedEmails.slice(0, this.state.displayedEmails.length + 20)
-            this.setState({displayedEmails: emailsToBeDisplayed});
+            this.setState({ displayedEmails: emailsToBeDisplayed });
         } else {
             this.getMessages().then((emails) => {
-                this.setState({loadedEmails: emails});
+                this.setState({ loadedEmails: emails });
 
                 var emailsToBeDisplayed = emails.slice(0, this.state.displayedEmails.length + 20);
-                this.setState({displayedEmails: emailsToBeDisplayed});
+                this.setState({ displayedEmails: emailsToBeDisplayed });
             });
         }
     }
@@ -299,12 +315,12 @@ export default class InboxPageComponent extends React.Component {
                 for (var i = 0; i < 10; i++) {
                     try {
                         var alreadyLoaded = false;
-                        newLoadedEmails.forEach(loadedEmail => {
+                        newLoadedEmails.forEach((loadedEmail) => {
                             if (loadedEmail.id == messageIds[i].id) {
                                 alreadyLoaded = true;
                             }
                         });
-        
+
                         if (!alreadyLoaded) {
                             newEmails.push(this.getMessage(messageIds[i].id));
                         }
@@ -318,25 +334,25 @@ export default class InboxPageComponent extends React.Component {
                 });
             }).then((newEmails) => {
                 if (newEmails.length > 0) {
-                    newEmails.forEach(newEmail => {
+                    newEmails.forEach((newEmail) => {
                         newLoadedEmails.unshift(newEmail);
                         newDisplayEmails.unshift(newEmail);
                     });
 
                     console.log("New emails processed:");
                     console.log(newEmails);
-        
+
                     this.setState({
                         loadedEmails: newLoadedEmails,
-                        displayedEmails: newDisplayEmails
-                    })
+                        displayedEmails: newDisplayEmails,
+                    });
                 }
             });
         }
     }
 
     toggleCreateEmailModal() {
-        this.setState({createEmailModalIsOpen: !this.state.createEmailModalIsOpen});
+        this.setState({ createEmailModalIsOpen: !this.state.createEmailModalIsOpen });
     }
 
     Search() {
@@ -346,7 +362,9 @@ export default class InboxPageComponent extends React.Component {
                     <input
                         type="text"
                         value={this.state.searchTerm}
-                        onBlur={(e) => this.setState({searchTerm: e.target.value})}
+                        onBlur={(e) =>
+                            this.setState({ searchTerm: e.target.value })
+                        }
                     />
                     <input type="submit" value="Submit" />
                     <button type="button" onClick={(e) => this.handleReset(e)}>
@@ -357,31 +375,34 @@ export default class InboxPageComponent extends React.Component {
         );
     }
 
-    handleSubmit(event){
+    handleSubmit(event) {
         this.getMessages().then((emails) => {
-            this.setState({loadedEmails: emails});
+            this.setState({ loadedEmails: emails });
 
             var emailsToBeDisplayed = emails.slice(0, this.state.displayedEmails.length + 20);
-            this.setState({displayedEmails: emailsToBeDisplayed});
+            this.setState({ displayedEmails: emailsToBeDisplayed });
         });
-        this.setState({refreshEnabled: false});
+        this.setState({ refreshEnabled: false });
         event.preventDefault();
     }
 
     handleReset(event) {
-        this.setState({searchTerm: null})
+        this.setState({ searchTerm: null });
         this.getMessages().then((emails) => {
-            this.setState({loadedEmails: emails});
+            this.setState({ loadedEmails: emails });
 
-            var emailsToBeDisplayed = emails.slice(0, this.state.displayedEmails.length + 20);
-            this.setState({displayedEmails: emailsToBeDisplayed});
+            var emailsToBeDisplayed = emails.slice(
+                0,
+                this.state.displayedEmails.length + 20
+            );
+            this.setState({ displayedEmails: emailsToBeDisplayed });
         });
-        this.setState({refreshEnabled: true});
+        this.setState({ refreshEnabled: true });
         event.preventDefault();
     }
 
     // Call to API to get data about the attachment 
-    async getAttachmentData(messageID, parts){
+    async getAttachmentData(messageID, parts) {
         var attachId = parts.body.attachmentId;
         var request = window.gapi.client.gmail.users.messages.attachments
             .get({
@@ -394,9 +415,9 @@ export default class InboxPageComponent extends React.Component {
 
     componentDidMount() {
         this.getMessages().then((emails) => {
-            this.setState({loadedEmails: emails});
+            this.setState({ loadedEmails: emails });
 
-            this.setState({displayedEmails: emails.slice(0, this.state.displayedEmails.length + 20)});
+            this.setState({ displayedEmails: emails.slice(0, this.state.displayedEmails.length + 20) });
         })
 
         setInterval(() => {

--- a/ec_email_client/src/components/InboxPageComponent.js
+++ b/ec_email_client/src/components/InboxPageComponent.js
@@ -206,7 +206,23 @@ export default class InboxPageComponent extends React.Component {
                         ) {
                             message.bodyHTML = message.bodyText;
                         }
-                    } else {
+                    } else if (response.result.payload.parts.length == 1 && response.result.payload.parts[0].parts
+                        && response.result.payload.parts[0].parts.length == 1 && response.result.payload.parts[0].parts[0].mimeType == "text/html") {
+                        switch (response.result.payload.parts[0].parts[0].mimeType) {
+                            case "text/plain":
+                                message.bodyText = this.decodeBase64HTML(
+                                    response.result.payload.parts[0].parts[0].body.data
+                                );
+                                break;
+
+                            case "text/html":
+                                message.bodyHTML = this.decodeBase64HTML(
+                                    response.result.payload.parts[0].parts[0].body.data
+                                );
+                                break;
+                        }
+                    }
+                    else {
                         console.log(
                             "Failed getting message body for:",
                             response.result
@@ -241,6 +257,10 @@ export default class InboxPageComponent extends React.Component {
                     message.headers = headers;
 
                     message.id = response.result.id;
+                    if (message.id == "1753f0c7fcbb8c2a") {
+                        console.log(response.result);
+                    }
+
                     resolve(message);
                 });
         });

--- a/ec_email_client/src/pages/CreateEmail.js
+++ b/ec_email_client/src/pages/CreateEmail.js
@@ -212,27 +212,26 @@ class EmailComposition extends React.Component {
         var toSend = this.state.recipient.replace(",", ", ");
         var CCs = this.state.cc.replace(",", ", ");
 
-        // TODO: Possible make content editable div to render HTML? Or maybe just display reply email below the text are as a div
-        // https://stackoverflow.com/questions/4705848/rendering-html-inside-textarea
-
-        // Could just make all newLines be <br /> or something?
-
-        var messageParts = [
-            `To: ${toSend}`,
-            `CC: ${CCs}`,
-            "Content-Type: text/html; charset=utf-8",
-            "MIME-Version: 1.0",
-            `Subject: ${utf8Subject}`,
-            "",
-            messageContent,
-        ];
+        let messageParts = null;
+        // https://www.npmjs.com/package/mimemessage
+        let msg = mimemessage.factory({
+            contentType: "multipart/mixed",
+            body: [],
+        });
+        msg.header("To", toSend);
+        msg.header("CC", CCs);
+        msg.header("Subject", utf8Subject);
+        let alternateEntity = mimemessage.factory({
+            contentType: "multipart/alternate",
+            body: [],
+        });
+        let htmlEntity = mimemessage.factory({
+            contentType: "text/html;charset=utf-8",
+            body: messageContent,
+        });
 
         // If reply
         if (this.props.reply) {
-            let tempSubject = `=?utf-8?B?${Buffer.from(
-                `${utf8Subject}`
-            ).toString("base64")}?=`;
-
             let inReplyTo = this.props.replyMessage.headers["Message-Id"];
 
             let references = inReplyTo;
@@ -240,59 +239,15 @@ class EmailComposition extends React.Component {
                 references = `${inReplyTo},${this.props.replyMessage.headers["References"]}`;
             }
 
+            msg.header("In-Reply-To", inReplyTo);
+            msg.header("Reply-To", this.props.replyMessage.to)
+            msg.header("References", references);
+
             threadId = this.props.replyMessage.threadId;
-
-            messageParts = [
-                `To: ${toSend}`,
-                `CC: ${CCs}`,
-                "Content-Type: text/html; charset=utf-8",
-                "MIME-Version: 1.0",
-                `Subject: ${tempSubject}`,
-                `In-Reply-To: ${inReplyTo}`,
-                `Reply-To: ${this.props.replyMessage.to}`,
-                `References: ${references}`,
-                "",
-                messageContent,
-            ];
         }
-
-        // If forward
-        if (this.props.forward) {
-            let tempSubject = `=?utf-8?B?${Buffer.from(
-                `${utf8Subject}`
-            ).toString("base64")}?=`;
-
-            messageParts = [
-                `To: ${toSend}`,
-                `CC: ${CCs}`,
-                "Content-Type: text/html; charset=utf-8",
-                "MIME-Version: 1.0",
-                `Subject: ${tempSubject}`,
-                "",
-                messageContent,
-            ];
-        }
-
-        // TODO: See if adding an attachment to a reply messes it up??
 
         //If the email has an attachment, it needs to use the multipart structure
         if (this.state.file && this.state.file != "") {
-            // https://www.npmjs.com/package/mimemessage
-            let msg = mimemessage.factory({
-                contentType: "multipart/mixed",
-                body: [],
-            });
-            msg.header("To", toSend);
-            msg.header("CC", CCs);
-            msg.header("Subject", utf8Subject);
-            let alternateEntity = mimemessage.factory({
-                contentType: "multipart/alternate",
-                body: [],
-            });
-            let htmlEntity = mimemessage.factory({
-                contentType: "text/html;charset=utf-8",
-                body: messageContent,
-            });
             let attachEntity = mimemessage.factory({
                 contentType: this.state.file.type,
                 contentTransferEncoding: "base64",
@@ -302,19 +257,13 @@ class EmailComposition extends React.Component {
                 "Content-Disposition",
                 `attachment ;filename="${this.state.file.name}"`
             );
-            alternateEntity.body.push(htmlEntity);
-            msg.body.push(alternateEntity);
             msg.body.push(attachEntity);
-            messageParts = msg.toString();
         }
 
-        let message = null;
-        if (typeof messageParts != "string") {
-            message = messageParts.join("\n");
-        } else {
-            message = messageParts;
-            console.log(message);
-        }
+        alternateEntity.body.push(htmlEntity);
+        msg.body.push(alternateEntity);
+        let message = msg.toString();
+
 
         // The body needs to be base64url encoded.
         const encodedMessage = Buffer.from(message)


### PR DESCRIPTION
In order to prevent dealing with the headache of manually crafting the headers for all types of messages we send, I found a node package called `mimemessage` which helps format a MIME message for you. We create a new MIME message object and just add in additional headers and attachments as needed. 

The new node package helps format the header just right so that the body of the message never interferes with the headers, so the highlighting and other weird messages seem to be displaying correctly. 

I also fixed some displaying issues whenever the contents of the message is buried in some nested 'parts' within the message object.

To Test:
- [ ] Send normal message
- [ ] Send message with highlighting
- [ ] Reply to message
- [ ] Send an attachment with highlighting
- [ ] Reply to a message with an attachment
- [ ] Reply to a message with a highlight and an attachment :)

NOTE: I realized towards the end that my auto-formatter was re-formatting code other people had written, I tried to revert it all, but if I forgot any, I apologize, lol.

Closes #36 
Closes #46 